### PR TITLE
[CLOUD-1851] use standalone.xml for Business Central

### DIFF
--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -15,7 +15,7 @@ cmd:
     - "-b"
     - "0.0.0.0"
     - "-c"
-    - "standalone-full.xml"
+    - "standalone.xml"
 scripts:
     - package: businesscentral
       exec: install


### PR DESCRIPTION
Business Central no longer requires standalone-full.xml, as it is not
using JMS anymore.

@errantepiphany could you please take a look? If the only reason for the `standlaone-full.xml` was the JMS then I believe it is not needed anymore.