### PR TITLE
[CLOUD-1850] use root context (/) for the WARs

### DIFF
--- a/businesscentral/scripts/businesscentral/install
+++ b/businesscentral/scripts/businesscentral/install
@@ -8,6 +8,8 @@ unzip $SOURCES_DIR/jboss-bpmsuite-7.0.0.CAP01-business-central-eap7.zip -d $SOUR
 chmod 0755 ${SOURCES_DIR}/jboss-eap-7.0
 
 cp -rf ${SOURCES_DIR}/jboss-eap-7.0/* $JBOSS_HOME/
+mv "$JBOSS_HOME/standalone/deployments/business-central.war" "$JBOSS_HOME/standalone/deployments/ROOT.war"
+mv "$JBOSS_HOME/standalone/deployments/business-central.war.dodeploy" "$JBOSS_HOME/standalone/deployments/ROOT.war.dodeploy"
 
 chown -R jboss:root $JBOSS_HOME
 chmod 0755 $JBOSS_HOME

--- a/businesscentral/tests/features/businesscentral.feature
+++ b/businesscentral/tests/features/businesscentral.feature
@@ -5,6 +5,6 @@ Feature: Standalone Business Central tests
     Then check that page is served
          | property | value |
          | port     | 8080  |
-         | path     | /business-central/kie-wb.jsp |
+         | path     | /kie-wb.jsp |
          | expected_status_code | 200 |
 

--- a/executionserver/scripts/executionserver/install
+++ b/executionserver/scripts/executionserver/install
@@ -6,8 +6,8 @@ SOURCES_DIR=/tmp/artifacts
 
 unzip $SOURCES_DIR/jboss-bpmsuite-7.0.0.CAP01-execution-server-ee7.zip -d $SOURCES_DIR
 
-cp -rf ${SOURCES_DIR}/jboss-brms-bpmsuite-7.0-execution-server-ee7/kie-execution-server.war $JBOSS_HOME/standalone/deployments/
-touch $JBOSS_HOME/standalone/deployments/kie-execution-server.war.dodeploy
+cp -rf ${SOURCES_DIR}/jboss-brms-bpmsuite-7.0-execution-server-ee7/kie-execution-server.war $JBOSS_HOME/standalone/deployments/ROOT.war
+touch $JBOSS_HOME/standalone/deployments/ROOT.war.dodeploy
 cp -rf ${SOURCES_DIR}/jboss-brms-bpmsuite-7.0-execution-server-ee7/SecurityPolicy/* $JBOSS_HOME/bin/
 
 chown -R jboss:root $JBOSS_HOME

--- a/executionserver/tests/features/executionserver.feature
+++ b/executionserver/tests/features/executionserver.feature
@@ -5,7 +5,7 @@ Feature: Standalone Execution Server tests
     Then check that page is served
          | property | value |
          | port     | 8080  |
-         | path     | /kie-execution-server/services/rest/server |
+         | path     | /services/rest/server |
          | expected_status_code | 401 |
 
    Scenario: Test REST API is available and valid
@@ -13,7 +13,7 @@ Feature: Standalone Execution Server tests
      Then check that page is served
          | property | value |
          | port     | 8080  |
-         | path     | /kie-execution-server/services/rest/server |
+         | path     | /services/rest/server |
          | username | kieserver |
          | password | kieserver1! |
          | expected_phrase | SUCCESS |


### PR DESCRIPTION
Using root context is more user-friendly as users don't need to know the
specific context the app was deployed to.

@errantepiphany WDYT? Is this a good idea? Are there any disadvantages to this approach?