### PR TITLE
Invoke smart router java command using exec

### DIFF
--- a/smartrouter/scripts/smartrouter/start
+++ b/smartrouter/scripts/smartrouter/start
@@ -18,5 +18,5 @@ if [ "$KIE_ROUTER_CONTROLLER_URL_EXTERNAL" != "" ]; then
     ROUTER_OPTS="$ROUTER_OPTS -Dorg.kie.server.router.url.external=${KIE_ROUTER_CONTROLLER_URL_EXTERNAL}"
 fi
 
-${JAVA_HOME}/bin/java ${ROUTER_OPTS} \
+exec ${JAVA_HOME}/bin/java ${ROUTER_OPTS} \
     -jar /opt/${JBOSS_PRODUCT}/${KIE_ROUTER_DISTRIBUTION_ARTIFACT}


### PR DESCRIPTION
Without exec the SIGTERM signal (invoked by Docker when stopping container) isn't propagated to java. Without this propagation the smart router isn't unregistered from Workbench - unregistration is invoked using shutdown hook.

@rbarriuso @errantepiphany Please look on it in your spare time.