### PR TITLE
Fix the monitoring assembly issue for Beta01 upates

### DIFF
--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -11,7 +11,7 @@ envs:
     - name: "PRODUCT_VERSION"
       value: "7.0.0"
     - name: "BUSINESS_CENTRAL_MONITORING_DISTRIBUTION_ZIP"
-      value: "jboss-bpmsuite-7.0.0.Beta01-business-central-monitoring-ee7.zip"
+      value: "jboss-bpmsuite-7.0.0.Beta01-business-central-monitoring-eap7.zip"
 cmd:
     - "/opt/eap/bin/standalone.sh"
     - "-b"
@@ -22,7 +22,7 @@ scripts:
     - package: businesscentral-monitoring
       exec: install
 sources:
-    - artifact: jboss-bpmsuite-7.0.0.Beta01-business-central-monitoring-ee7.zip
-      md5: 57ebeac2d7f66fcf2654a147d30ec6ed
+    - artifact: jboss-bpmsuite-7.0.0.Beta01-business-central-monitoring-eap7.zip
+      md5: f2640f5d4cfa1d41d1eb664b4037930a
 dogen:
     version: 2.4.1


### PR DESCRIPTION
Fix the bc-monitoring image error caused by different assembly structure in the -monitoring zip file.