### PR TITLE
Specify modules explicitly - la branch

### DIFF
--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -21,6 +21,8 @@ envs:
     - name: "BUSINESS_CENTRAL_MONITORING_DISTRIBUTION_ZIP"
       value: "jboss-bpmsuite-7.0.0.LA-business-central-monitoring-eap7.zip"
 modules:
+      repositories:
+          - path: modules
       install:
           - name: businesscentral-monitoring
 artifacts:

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -21,6 +21,8 @@ envs:
     - name: "BUSINESS_CENTRAL_DISTRIBUTION_ZIP"
       value: "jboss-bpmsuite-7.0.0.LA-business-central-eap7.zip"
 modules:
+      repositories:
+          - path: modules
       install:
           - name: businesscentral
 artifacts:

--- a/executionserver/image.yaml
+++ b/executionserver/image.yaml
@@ -21,6 +21,8 @@ envs:
     - name: "KIE_SERVER_DISTRIBUTION_ZIP"
       value: "jboss-bpmsuite-7.0.0.LA-execution-server-ee7.zip"
 modules:
+      repositories:
+          - path: modules
       install:
           - name: executionserver
 artifacts:

--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -21,6 +21,8 @@ envs:
     - name: "KIE_ROUTER_DISTRIBUTION_JAR"
       value: "jboss-bpmsuite-7.0.0.LA-smart-router.jar"
 modules:
+      repositories:
+          - path: modules
       install:
           - name: smartrouter
 artifacts:

--- a/standalonecontroller/image.yaml
+++ b/standalonecontroller/image.yaml
@@ -21,6 +21,8 @@ envs:
     - name: "KIE_SERVER_CONTROLLER_DISTRIBUTION_ZIP"
       value: "jboss-bpmsuite-7.0.0.LA-execution-server-controller-ee7.zip"
 modules:
+      repositories:
+          - path: modules
       install:
           - name: standalonecontroller
 artifacts:


### PR DESCRIPTION
After upgrade to Concreate 1.3 lack of specifying path to modules may break the build.